### PR TITLE
🚸 'reset' option for `boostsrl.system_manager`

### DIFF
--- a/boostsrl/system_manager.py
+++ b/boostsrl/system_manager.py
@@ -6,6 +6,75 @@ from enum import Enum
 from enum import unique
 import pathlib
 import shutil
+import os
+
+__all__ = ["reset", "FileSystem"]
+
+
+def reset(soft=False):
+    """Reset the FileSystem
+
+    In some circumstances, a :class:`FileSystem` object may not properly clean up
+    temporary files on object deallocation. This function performs a hard reset
+    by explicitly removing the directory tree from the operating system.
+
+    Parameters
+    ----------
+    soft : bool (Default: False)
+        A *soft reset* reports the contents without removing.
+
+    Returns
+    -------
+    results : list
+        A "soft reset" returns a list of the contents.
+        A "hard reset" returns an empty list.
+
+    Notes
+    -----
+
+    Since the FileSystem object reads and writes from a location alongside
+    the package, these files are also removed when the package is uninstalled.
+    But uninstalling and reinstalling is overkill when a solution like this
+    is available.
+
+    Examples
+    --------
+
+    This method has a few uses. This could be used for cleaning up your
+    operating system in the event of failure. It could be a shorthand
+    method for triggering behavior when the data directory is/not empty.
+    Or the obvious case where you need to ensure temporary files are gone.
+
+    1. Use a "soft reset" to list contents without removing:
+
+    .. code-block:: bash
+
+        $ python -c "from boostsrl import system_manager; print(system_manager.reset(soft=True))"
+        ['data0', 'data1']
+
+    2. Trigger conditional behavior. Here we report that the directory is empty.
+
+    >>> from boostsrl import system_manager
+    >>> if not system_manager.reset(soft=True):
+    ...     print("Currently Empty")
+    Currently Empty
+
+    3. Use a hard reset to remove any temporary files.
+
+    >>> from boostsrl import system_manager
+    >>> system_manager.reset()
+    []
+    """
+    _here = pathlib.Path(__file__).parent
+    _data = _here.joinpath(FileSystem.boostsrl_data_directory)
+
+    if not _data.exists():
+        return []
+    if soft:
+        return os.listdir(_data)
+
+    shutil.rmtree(_data)
+    return []
 
 
 class FileSystem:

--- a/boostsrl/tests/test_system_manager_reset.py
+++ b/boostsrl/tests/test_system_manager_reset.py
@@ -22,7 +22,7 @@ def test_soft_reset_with_dirs():
     _there.joinpath("data2").mkdir(parents=True)
 
     result = system_manager.reset(soft=True)
-    assert result == ["data1", "data2"]
+    assert sorted(result) == sorted(["data1", "data2"])
     result = system_manager.reset()
     assert result == []
     result = system_manager.reset(soft=True)

--- a/boostsrl/tests/test_system_manager_reset.py
+++ b/boostsrl/tests/test_system_manager_reset.py
@@ -1,0 +1,37 @@
+# Copyright © 2017, 2018, 2019 Alexander L. Hayes
+
+"""
+Tests for boostsrl.system_manager.reset
+"""
+
+import pathlib
+from boostsrl import system_manager
+
+
+def test_soft_reset():
+    """Test performing a soft reset."""
+    result = system_manager.reset(soft=True)
+    assert result == []
+
+
+def test_soft_reset_with_dirs():
+    """Soft reset when the directory is non-empty."""
+    _dir = pathlib.Path(system_manager.__file__).parent
+    _there = _dir.joinpath(system_manager.FileSystem.boostsrl_data_directory)
+    _there.joinpath("data1").mkdir(parents=True)
+    _there.joinpath("data2").mkdir(parents=True)
+
+    result = system_manager.reset(soft=True)
+    assert result == ["data1", "data2"]
+    result = system_manager.reset()
+    assert result == []
+    result = system_manager.reset(soft=True)
+    assert result == []
+
+
+def test_hard_reset():
+    """Hard reset should return []"""
+    result = system_manager.reset(soft=False)
+    assert result == []
+    result = system_manager.reset()
+    assert result == []

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -27,6 +27,24 @@ Data Sets
 
    example_data
 
+Utilities
+=========
+
+These modules are generally for behind-the-scenes operations or things that
+should typically be handled on your behalf.
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   system_manager.FileSystem
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   system_manager.reset
+
 Deprecated boostsrl objects
 ===========================
 
@@ -37,15 +55,3 @@ actively developed and is pending removal in 0.6.0.
    :toctree: generated/
 
    boostsrl.boostsrl
-
-Advanced
-========
-
-These features are generally for behind-the-scenes operations or things that
-should typically be handled on your behalf.
-
-.. autosummary::
-   :toctree: generated/
-   :template: class.rst
-
-   system_manager.FileSystem


### PR DESCRIPTION
- Add boostsrl.system_manager.reset() function to remove bsrl_data
- Add unit tests for reset() function
- Add documentation for reset() function
- Rearrange api.rst, replacing "Advanced" with "Utilities" and
  listing it first

'reset' is a utility function to help handle cases where the
`bsrl_data` directory may not have been cleaned up properly
when FileSystem objects are deallocated.

Usage
-----

```python
>>> from boostsrl import system_manager
>>> system_manager.reset()
```

Use cases
---------

- `boostsrl.system_manager.reset(soft=True)`
  Lists the contents of `bsrl_data` ([] if it does not exist)

- `boostsrl.system_manager.reset(soft=False)`
  Removes the directory tree from the user's operating system