### PR TITLE
[MRG] 🏗️ `boostsrl.base.BaseBoostedRelationalModel` base class

### DIFF
--- a/boostsrl/base.py
+++ b/boostsrl/base.py
@@ -17,7 +17,38 @@ from ._meta import DEBUG
 class BaseBoostedRelationalModel(BaseEstimator, ClassifierMixin):
     """Base class for deriving boosted relational models
 
-    Wrappers around BoostSRL for instantiating and running the jar files.
+    This class extends :class:`sklearn.base.BaseEstimator` and
+    :class:`sklearn.base.ClassifierMixin` while providing several utilities
+    for instantiating a model and performing learning/inference with the
+    BoostSRL jar files.
+
+    .. note:: This is not a complete treatment of *how to derive estimators*.
+        Contributions would be appreciated.
+
+    Examples
+    --------
+
+    The actual :class:`boostsrl.rdn.RDN` is derived from this class, so this
+    example is similar to the implementation (but the actual implementation
+    passes model parameters instead of leaving them with the defaults).
+    This example derives a new class ``RDN``, which inherits the default
+    values of the superclass while also setting a 'special_parameter' which
+    may be unique to this model.
+
+    All that remains is to implement the specific cases of ``fit()``,
+    ``predict()``, and ``predict_proba()``.
+
+    >>> from boostsrl.base import BaseBoostedRelationalModel
+    >>> class RDN(BaseBoostedRelationalModel):
+    ...     def __init__(self, special_parameter=5):
+    ...         super().__init__(self)
+    ...         self.special_parameter = special_parameter
+    ...
+    >>> dn = RDN(special_parameter=8)
+    >>> print(dn)
+    RDN(special_parameter=8)
+    >>> print(dn.n_estimators)
+    10
     """
 
     # pylint: disable=too-many-instance-attributes
@@ -29,7 +60,6 @@ class BaseBoostedRelationalModel(BaseEstimator, ClassifierMixin):
         n_estimators=10,
         node_size=2,
         max_tree_depth=3,
-
     ):
         """Initialize a BaseEstimator"""
         self.background = background

--- a/boostsrl/base.py
+++ b/boostsrl/base.py
@@ -1,0 +1,120 @@
+# Copyright © 2017, 2018, 2019 Alexander L. Hayes
+
+"""
+Base class for Boosted Relational Models
+"""
+
+from sklearn.base import BaseEstimator
+from sklearn.base import ClassifierMixin
+from sklearn.utils.validation import check_is_fitted
+import subprocess
+
+from .background import Background
+from .system_manager import FileSystem
+from ._meta import DEBUG
+
+
+class BaseBoostedRelationalModel(BaseEstimator, ClassifierMixin):
+    """Base class for deriving boosted relational models
+
+    Wrappers around BoostSRL for instantiating and running the jar files.
+    """
+
+    # pylint: disable=too-many-instance-attributes
+
+    def __init__(
+        self,
+        background=None,
+        target="None",
+        n_estimators=10,
+        node_size=2,
+        max_tree_depth=3,
+
+    ):
+        """Initialize a BaseEstimator"""
+        self.background = background
+        self.target = target
+        self.n_estimators = n_estimators
+        self.node_size = node_size
+        self.max_tree_depth = max_tree_depth
+        self.debug = DEBUG
+
+    def _check_params(self):
+        """Check validity of parameters. Raise ValueError if errors are detected.
+
+        If all parameters are valid, instantiate ``self.file_system`` by
+        instantiating it with a :class:`boostsrl.system_manager.FileSystem`
+        """
+        if self.target == "None":
+            raise ValueError("target must be set, cannot be {0}".format(self.target))
+        if not isinstance(self.target, str):
+            raise ValueError(
+                "target must be a string, cannot be {0}".format(self.target)
+            )
+        if self.background is None:
+            raise ValueError(
+                "background must be set, cannot be {0}".format(self.background)
+            )
+        if not isinstance(self.background, Background):
+            raise ValueError(
+                "background should be a boostsrl.Background object, cannot be {0}".format(
+                    self.background
+                )
+            )
+        if not isinstance(self.n_estimators, int) or isinstance(
+            self.n_estimators, bool
+        ):
+            raise ValueError(
+                "n_estimators must be an integer, cannot be {0}".format(
+                    self.n_estimators
+                )
+            )
+        if self.n_estimators <= 0:
+            raise ValueError(
+                "n_estimators must be greater than 0, cannot be {0}".format(
+                    self.n_estimators
+                )
+            )
+
+        # If all params are valid, allocate a FileSystem:
+        self.file_system = FileSystem()
+
+    def _check_initialized(self):
+        """Check for the estimator(s), raise an error if not found."""
+        check_is_fitted(self, "estimators_")
+
+    @staticmethod
+    def _call_shell_command(shell_command):
+        """Start a new process to execute a shell command.
+
+        This is intended for use in calling jar files. It opens a new process and
+        waits for it to return 0.
+
+        Parameters
+        ----------
+        shell_command : str
+            A string representing a shell command.
+
+        Returns
+        -------
+        None
+        """
+
+        # TODO: Explore other ways to interface with BoostSRL or the JVM.
+        #   https://wiki.python.org/moin/IntegratingPythonWithOtherLanguages#Java
+
+        _pid = subprocess.Popen(shell_command, shell=True)
+        _status = _pid.wait()
+        if _status != 0:
+            raise RuntimeError(
+                "Error when running shell command: {0}".format(shell_command)
+            )
+
+    def fit(self, database):
+        raise NotImplementedError
+
+    def predict(self, database):
+        raise NotImplementedError
+
+    def predict_proba(self, database):
+        raise NotImplementedError

--- a/boostsrl/tests/test_base.py
+++ b/boostsrl/tests/test_base.py
@@ -1,0 +1,43 @@
+# Copyright © 2017, 2018, 2019 Alexander L. Hayes
+
+"""
+Tests for boostsrl.base.BaseBoostedRelationalModel
+"""
+
+import pytest
+from boostsrl.base import BaseBoostedRelationalModel
+
+
+def test_initialize_base_classifier():
+    """Initialize a base classifier with default parameters."""
+    _bm = BaseBoostedRelationalModel()
+    assert _bm.target == "None"
+    assert _bm.n_estimators == 10
+
+
+@pytest.mark.parametrize("test_input", [4, 10, 20])
+def test_initialize_base_classifier_trees(test_input):
+    """Initialize a BaseModel with various tree numbers."""
+    _bm = BaseBoostedRelationalModel(n_estimators=test_input)
+    assert _bm.n_estimators == test_input
+
+
+def test_bad_fit():
+    """Check that fit raises a NotImplementedError"""
+    _bm = BaseBoostedRelationalModel()
+    with pytest.raises(NotImplementedError):
+        _bm.fit("database")
+
+
+def test_bad_predict():
+    """Check that predict raises a NotImplementedError"""
+    _bm = BaseBoostedRelationalModel()
+    with pytest.raises(NotImplementedError):
+        _bm.predict("database")
+
+
+def test_bad_predict_proba():
+    """Check that predict_proba raises a NotImplementedError"""
+    _bm = BaseBoostedRelationalModel()
+    with pytest.raises(NotImplementedError):
+        _bm.predict_proba("database")

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,13 +30,15 @@ Data Sets
 Utilities
 =========
 
-These modules are generally for behind-the-scenes operations or things that
-should typically be handled on your behalf.
+Some of these are for behind-the-scenes operations, but tend to
+be useful for further development
+(`contributions are welcome! <https://github.com/starling-lab/boostsrl-python-package/blob/master/.github/CONTRIBUTING.md>`_).
 
 .. autosummary::
    :toctree: generated/
    :template: class.rst
 
+   base.BaseBoostedRelationalModel
    system_manager.FileSystem
 
 .. autosummary::


### PR DESCRIPTION
## Status

Structural change adding a `boostsrl.base.BaseBoostedRelationalModel` for deriving new estimators. 

- [X] Add base class
- [X] Refactor RDN to use the base class
- [X] Documentation for building estimators (short guide)
- [X] Unit tests

## Overview

- Add `boostsrl/base.py` base class for deriving estimators
- Add `boostsrl/tests/test_base.py` to test this base class
- Refactor `boostsrl/rdn.py` to use the base class
- Add short intro to deriving new estimators in the `base.BaseBoostedRelationalModel` docstring
- Add link to the documentation under the Utilities section of the API doc

Several estimators will need to be derived which need access
to a common set of methods. This base class handles the logic
for verifying parameters, checking estimators, and leaves
`fit()`, `predict()` and `predict_proba()` NotImplemented.

This is intended to help prevent code duplication as other
methods (Markov Logic Networks, RDNRegression, etc.) are
added (e.g. #18 ).